### PR TITLE
Step 04 submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ erDiagram
     }
     LECTURE {
         id bigint PK "특강 ID"
+        start_at timestamp PK "수업 날짜"
         name varchar "특강 이름"
         capacity int "수강 인원"
         open_at timestamp "열리는 날짜"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ erDiagram
         open_at timestamp "열리는 날짜"
     }
     STUDENT_LECTURE {
-        user_id bigint FK "학생 ID"
+        student_id bigint FK "학생 ID"
         lecture_id bigint FK "특강 ID"
         enrollment bool "수강 여부"
         apply_at timestamp "신청 시간"

--- a/README.md
+++ b/README.md
@@ -3,49 +3,15 @@
 - `특강 신청 서비스`를 구현해 봅니다.
 - 항해 플러스 토요일 특강을 신청할 수 있는 서비스를 개발합니다.
 - 특강 신청 및 신청자 목록 관리를 RDBMS를 이용해 관리할 방법을 고민합니다.
-
 ## Requirements
-
-- 아래 2가지 API 를 구현합니다.
-    - 특강 신청 API
-    - 특강 신청 여부 조회 API
+- ERD 작성 및 당위성 증명합니다.
+- 아래 3가지 API 를 구현합니다.
+  - 특강 신청 API
+  - 특강 신청 여부 조회 API
+  - 특강 목록 조회 API
 - 각 기능 및 제약 사항에 대해 단위 테스트를 반드시 하나 이상 작성하도록 합니다.
 - 다수의 인스턴스로 어플리케이션이 동작하더라도 기능에 문제가 없도록 작성하도록 합니다.
 - 동시성 이슈를 고려하여 구현합니다.
-
-## API Specs
-
-1️⃣ **(핵심)** 특강 신청 **API `POST /lectures/apply`**
-
-- 특정 userId 로 선착순으로 제공되는 특강을 신청하는 API 를 작성합니다.
-- 동일한 신청자는 한 번의 수강 신청만 성공할 수 있습니다.
-- 특강은 `4월 20일 토요일 1시` 에 열리며, 선착순 30명만 신청 가능합니다.
-- 이미 신청자가 30명이 초과되면 이후 신청자는 요청을 실패합니다.
-- 어떤 유저가 특강을 신청했는지 히스토리를 저장해야한다.
-
-**2️⃣ (기본)** 특강 신청 완료 여부 조회 API **`GET /lectures/application/{userId}`**
-
-- 특정 userId 로 특강 신청 완료 여부를 조회하는 API 를 작성합니다.
-- 특강 신청에 성공한 사용자는 성공했음을, 특강 등록자 명단에 없는 사용자는 실패했음을 반환합니다. (true, false)
-
----
-
-### 심화 과제
-
-3️⃣ **(필수) 특강 선택 API `GET /lectures`**
-
-- 단 한번의 특강을 위한 것이 아닌 날짜별로 특강이 존재할 수 있는 범용적인 서비스로 변화시켜 봅니다.
-- 이를 수용하기 위해, 특강 엔티티의 경우 기존의 설계에서 변경되어야 합니다.
-- 특강의 정원은 30명으로 고정이며, 사용자는 각 특강에 신청하기전 목록을 조회해볼 수 있어야 합니다.
-    - 추가로 정원이 특강마다 다르다면 어떻게 처리할것인가..? 고민해 보셔라~
-
-<aside>
-💡 **KEY POINT**
-
-</aside>
-
-- 정확하게 30명의 사용자에게만 특강을 제공할 방법을 고민해 봅니다.
-- 같은 사용자에게 여러 번의 특강 슬롯이 제공되지 않도록 제한할 방법을 고민해 봅니다.
 
 ---
 
@@ -65,7 +31,7 @@ erDiagram
         capacity int "수강 인원"
         open_at timestamp "열리는 날짜"
     }
-    USER_LECTURE {
+    STUDENT_LECTURE {
         user_id bigint FK "학생 ID"
         lecture_id bigint FK "특강 ID"
         enrollment bool "수강 여부"
@@ -78,18 +44,24 @@ erDiagram
 최대한 적은 테이블과 필드 개수로 설계 했습니다.
 - 장점
   - 데이터 중복 최소화
-    - 저장 공간 절약
+    - 각 학생과 특강 정보는 별도의 테이블에 저장되어 중복을 최소화 합니다.
+      - 저장 공간 절약
+        - 중복 데이터가 없으므로 저장 공간을 절약할 수 있습니다.
   - 데이터 무결성 유지
-    - 외래 키 사용
+    - 외래 키를 사용하여 학생과 특강 간의 관계를 유지해 데이터 무결성을 보장합니다.
   - 유연성과 확장성
-    - 새로운 학생 / 특강이 추가 될 때 새로운 관계를 추가함으로써 확장 가능
+    - 새로운 학생 / 특강이 추가 될 때 새로운 관계를 추가함으로써 확장 가능 합니다.
 - 단점
   - 쿼리 복잡성
-    -  단순한 쿼리보다 조인을 사용해야 하므로 쿼리 복잡성이 증가
+    -  단순한 쿼리보다 조인을 사용해야 하므로 쿼리 복잡성이 증가 합니다.
   - 동시성 문제
     - ~~여러 트랜잭션이 중간테이블에 동시에 삽입/삭제/업데이트 시 일관성 유지 어려움~~
-      - 명세에서는 학생이 특강을 취소하는 경우를 고려하지 않음
-      - 삽입만 고려하면 됨
+      - 현재 명세에서는 학생이 특강을 취소하는 경우를 고려하지 않았습니다. 현재 구조는 삽입만을 고려합니다.
+
+이 설계는 데이터의 중복을 최소화하고 저장 공간을 절약하며
+데이터 무결성을 유지하는 데 강점을 가지고 있지만 취소 기능을 고려할 경우
+추가적인 설계가 필요합니다.
+
 ## Note
 ✅TEST : Add 'LectureControllerTest' for applyLecture feature
 ✨FEAT : Implement `LectureController` `applyLecture` method
@@ -99,15 +71,36 @@ erDiagram
   - `ApplyLectureService` or `ApplyLectureUseCaseImpl`
 
 ✅TEST : Add 'ApplyLectureServiceTest'
-- 결국 `ApplyLectureService`로 결정.
+- ~~결국 `ApplyLectureService`로 결정~~. Service가 UseCase의 상위 모듈이 아닌데, 상호 보완적인 관계라서 구현체라고 해야할지 잘 모르겠다.
 
 🎨REFACTOR : Add `LectureService` to handle the application logic and interact with `ApplyLectureUseCase`
 - 추후 서비스 될 수 있는 기능을 `UseCase`에 추가하고 실제로 서비스 되는 기능을 `Service`에 추가하는 설계(?).
 
 ✨FEAT : Update concurrency for applyLecture execute
 -  when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture))
-  이미 appyLecture 메서드를 호출하기 전에 리턴 대상(`Optional.of(lecture)`)을 지정해주는데
-  어떻게 applyLecutureUseCase 내에서 수강인원이 줄어드는 lecture를 리턴하는 걸까?
+   이미 appyLecture 메서드를 호출하기 전에 리턴 대상(`Optional.of(lecture)`)을 지정해주는데
+   어떻게 applyLecutureUseCase 내에서 수강인원이 줄어드는 lecture를 리턴하는 걸까?
 
 🔬SCOPE : Update concurrency for applyLecture execute using pessimistic locking
 - 메서드에서 임계 구간을 지정하기 보다 JPA 어노테이션으로 비관락을 설정.
+
+🎨 REFACTOR: Implement repositories to adhere to OCP and DIP
+- `Repository`의 OCP와 DIP를 지키기 위해, 다른 형태의 Repository도 JPA와 같은 메서드 명을 가져야 하는걸까?
+
+✨FEAT : Add feature to list lectures
+- 특강 목록 API 추가
+
+✨FEAT : Add feature to check lecture enrollment and its test code
+- 특강 신청 (완료) 여부 조회 API 추가
+  - `student_id`로 `student_lecture` 테이블을 조회하여 enrollment 값이 true인 Entity 필터링.
+    - 사용자가 특강 신청 한개라도 성공한다면 true 리턴.
+  - 확장성을 고려하여 단순히 true/false를 리턴하는 대신 ~~CheckLectureEnrollmentAPIResponse~~`EnrolledLectureAPIResponse`를 리턴.
+    - 사용자가 특강 신청 성공한 특강 목록 리턴.
+    - 사용자가 특강 신청한 모든 특강 목록 리턴.
+    - @RequestParam을 추가하여 `lecture_id`를 받아 특정 특강 신청 성공 여부 리턴.
+
+TBD :
+동시성 제어 테스트
+- 분산 환경에도 동시성 제어 하기 위해 Repository Layer에서 락을 해줘야 함.
+- 일단 JPA Repository 인터페이스 메서드가 익숙치 않아, 의도대로 동작을 하는지 확인.
+- JPA Repository 메서드에 비관적 락을 걸어보자.

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureCommand.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureCommand.java
@@ -1,5 +1,6 @@
 package io.hhplus.lecture_apply_service.application.port.in;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,5 +10,7 @@ public class ApplyLectureCommand {
 
     private Long studentId;
     private Long lectureId;
+    private LocalDateTime startAt;
+    private LocalDateTime requestAt;
 
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
@@ -32,12 +32,11 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
     @Override
     public ApplyLectureAPIResponse execute (ApplyLectureCommand command) {
       //유효한 특강ID 확인
-      LectureId lectureId = new LectureId(command.getLectureId(), command.getStartAt());
-      Lecture lecture = validateLecture(lectureId);
+      Lecture lecture = validateLecture(new LectureId(command.getLectureId(), command.getStartAt()));
       //유효한 학생ID 확인
       Student student = validateStudent(command.getStudentId());
       //이미 수강한 특강인지 확인
-      validateNotAlreadyApplied(student.getId(), lectureId);
+      validateNotAlreadyApplied(student.getId(), lecture.getId());
 
       //수강 인원 확인
       ApplyLectureAPIResponse response = handleLectureCapacity(student, lecture);
@@ -85,7 +84,8 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
   }
 
   private ApplyLectureAPIResponse handleLectureCapacity(Student student, Lecture lecture) {
-      return lecture.getCapacity() == 0 ? new ApplyLectureAPIResponse(student.getId(), lecture.getId().getLectureId(), lecture.getStartAt(), false) : null;
+      return lecture.getCapacity() == 0 ? new ApplyLectureAPIResponse(student.getId(), lecture.getId()
+          .getLectureId(), lecture.getId().getStartAt(), false) : null;
   }
 
 

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
@@ -26,6 +26,7 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
     private final StudentRepository studentRepository;
     private final StudentLectureRepository studentLectureRepository;
 
+
     @Transactional
     @Override
     public ApplyLectureAPIResponse execute (ApplyLectureCommand command) {
@@ -50,7 +51,7 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
 
       //수강인원 감소
       lecture.setCapacity(lecture.getCapacity()-1);
-      lectureRepository.savexLock(lecture);
+      lectureRepository.save(lecture);
 
       //수강신청 성공 히스토리 추가
       saveApplyHistory(student,lecture,true);
@@ -72,13 +73,13 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
   }
   private void validateNotAlreadyApplied(Long studentId, Long lectureId) {
     if (studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(studentId, lectureId)) {
-      throw new CustomException(ErrorCode.ALREADY_APPLIED);
+      throw new CustomException(ErrorCode.ALREADY_APPLIED, "Student :"+studentId+" Lecture  : "+lectureId);
     }
   }
 
   private Student validateStudent(Long studentId) {
-    return studentRepository.findById(studentId)
-        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_STUDENT_ID));
+    return studentRepository.findByIdxLock(studentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_STUDENT_ID, studentId.toString()));
   }
 
   private ApplyLectureAPIResponse handleLectureCapacity(Student student, Lecture lecture) {

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
@@ -1,81 +1,86 @@
 package io.hhplus.lecture_apply_service.application.port.in;
 
 import io.hhplus.lecture_apply_service.application.port.out.LectureLock;
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+
 import io.hhplus.lecture_apply_service.common.UseCase;
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.exception.CustomException;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentRepository;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
 import io.hhplus.lecture_apply_service.exception.ErrorCode;
-import java.util.Optional;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.Semaphore;
 
 
 @RequiredArgsConstructor
 @UseCase
 public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
 
-    private final LectureLock lectureLock;
     private final LectureRepository lectureRepository;
     private final StudentRepository studentRepository;
     private final StudentLectureRepository studentLectureRepository;
 
-    private final Semaphore semaphore = new Semaphore(1);
-
-
-
-    @Transactional
-    public ApplyLectureAPIResponse executeNope(ApplyLectureCommand command) {
-        try{
-            //semaphore.acquire();
-            LectureJpaEntity lectureJpaEntity = lectureRepository.findByIdxLock(command.getLectureId())
-                .orElseThrow(()->
-                    new CustomException(ErrorCode.INVALID_LECTURE_ID));
-            if (lectureJpaEntity.getCapacity() <= 0){
-                return new ApplyLectureAPIResponse(command.getStudentId(), command.getLectureId(), false);
-            }
-            lectureJpaEntity.setCapacity(lectureJpaEntity.getCapacity()-1);
-            lectureRepository.savexLock(lectureJpaEntity);
-            return new ApplyLectureAPIResponse(command.getStudentId(), command.getLectureId(), true);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }finally {
-            //semaphore.release();
-        }
-    }
-
     @Override
-    @Transactional
-    public ApplyLectureAPIResponse execute(ApplyLectureCommand command) {
-        try{
-            //semaphore.acquire();
-            LectureJpaEntity lectureJpaEntity = lectureRepository.findById(command.getLectureId())
-                    .orElseThrow(()->
-                            new CustomException(ErrorCode.INVALID_LECTURE_ID));
-            if (lectureJpaEntity.getCapacity() <= 0){
-                return new ApplyLectureAPIResponse(command.getStudentId(), command.getLectureId(), false);
-            }
+    public ApplyLectureAPIResponse execute (ApplyLectureCommand command) {
+      //유효한 특강ID 확인
+      Lecture lecture = validateLecture(command.getLectureId());
+      //유효한 학생ID 확인
+      Student student = validateStudent(command.getStudentId());
+      //이미 수강한 특강인지 확인
+      validateNotAlreadyApplied(student.getId(), command.getLectureId());
 
-            StudentJpaEntity studentJpaEntity = studentRepository.findById(command.getStudentId())
-                    .orElseThrow(()->
-                            new CustomException(ErrorCode.INVALID_STUDENT_ID));
+      //수강 인원 확인
+      ApplyLectureAPIResponse response = handleLectureCapacity(student, lecture);
+      if (response != null) {
+        //수강 인원 초과로 수강 실패
+        saveApplyHistory(student,lecture,false);
+        return response;
+      }
 
-            lectureJpaEntity.setCapacity(lectureJpaEntity.getCapacity()-1);
-            lectureRepository.save(lectureJpaEntity);
-            StudentLectureJpaEntity studentLecture = new StudentLectureJpaEntity(studentJpaEntity, lectureJpaEntity);
-            studentLectureRepository.save(studentLecture);
-            return new ApplyLectureAPIResponse(command.getStudentId(), command.getLectureId(), true);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }finally {
-            //semaphore.release();
-        }
+      if (LocalDateTime.now().isBefore(lecture.getOpen_at())){
+        throw new CustomException(ErrorCode.INVALID_TIME);
+      }
+
+      //수강인원 감소
+      lecture.setCapacity(lecture.getCapacity()-1);
+      lectureRepository.savexLock(lecture);
+
+      //수강신청 성공 히스토리 추가
+      saveApplyHistory(student,lecture,true);
+      return new ApplyLectureAPIResponse(command.getStudentId(), command.getLectureId(), true);
     }
+
+  private void saveApplyHistory(Student student, Lecture lecture, boolean enrollment) {
+    StudentLecture studentLecture = new StudentLecture(student, lecture, enrollment);
+    studentLectureRepository.save(studentLecture);
+  }
+
+  private Lecture validateLecture(Long lectureId) {
+      Lecture lecture = lectureRepository.findByIdxLock(lectureId)
+          .orElseThrow(()-> new CustomException(ErrorCode.INVALID_LECTURE_ID));
+      if (LocalDateTime.now().isBefore(lecture.getOpen_at())){
+        throw new CustomException(ErrorCode.INVALID_TIME);
+      }
+      return lecture;
+  }
+  private void validateNotAlreadyApplied(Long studentId, Long lectureId) {
+    if (studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(studentId, lectureId)) {
+      throw new CustomException(ErrorCode.ALREADY_APPLIED);
+    }
+  }
+
+  private Student validateStudent(Long studentId) {
+    return studentRepository.findById(studentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_STUDENT_ID));
+  }
+
+  private ApplyLectureAPIResponse handleLectureCapacity(Student student, Lecture lecture) {
+      return lecture.getCapacity() == 0 ? new ApplyLectureAPIResponse(student.getId(), lecture.getId(), false) : null;
+  }
+
+
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ApplyLectureUseCaseImpl.java
@@ -14,6 +14,8 @@ import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIRespo
 import io.hhplus.lecture_apply_service.exception.ErrorCode;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
 
 
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class ApplyLectureUseCaseImpl implements ApplyLectureUseCase {
     private final StudentRepository studentRepository;
     private final StudentLectureRepository studentLectureRepository;
 
+    @Transactional
     @Override
     public ApplyLectureAPIResponse execute (ApplyLectureCommand command) {
       //유효한 특강ID 확인

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/EnrolledLectureUseCase.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/EnrolledLectureUseCase.java
@@ -1,0 +1,9 @@
+package io.hhplus.lecture_apply_service.application.port.in;
+
+
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
+
+public interface EnrolledLectureUseCase {
+
+  EnrolledLectureAPIResponse execute(long userId);
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/EnrolledLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/EnrolledLectureUseCaseImpl.java
@@ -1,0 +1,20 @@
+package io.hhplus.lecture_apply_service.application.port.in;
+
+import io.hhplus.lecture_apply_service.common.UseCase;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class EnrolledLectureUseCaseImpl implements EnrolledLectureUseCase {
+  private final StudentLectureRepository studentLectureRepository;
+  @Override
+  public EnrolledLectureAPIResponse execute(long studentId) {
+    List<StudentLecture> enrolledLectures = studentLectureRepository.findAllByStudentId(studentId);
+    EnrolledLectureAPIResponse response = new EnrolledLectureAPIResponse(enrolledLectures, !enrolledLectures.isEmpty());
+    return response;
+  }
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCase.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCase.java
@@ -1,0 +1,10 @@
+package io.hhplus.lecture_apply_service.application.port.in;
+
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface ListLectureUseCase {
+
+  ListLectureAPIResponse execute();
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCaseImpl.java
@@ -1,0 +1,29 @@
+package io.hhplus.lecture_apply_service.application.port.in;
+
+import io.hhplus.lecture_apply_service.common.UseCase;
+import io.hhplus.lecture_apply_service.exception.CustomException;
+import io.hhplus.lecture_apply_service.exception.ErrorCode;
+import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@UseCase
+public class ListLectureUseCaseImpl implements ListLectureUseCase{
+  private final LectureRepository lectureRepository;
+
+  @Override
+  public ListLectureAPIResponse execute() {
+    List<LectureJpaEntity> lectures = lectureRepository.findAll();
+    return Optional.ofNullable(lectures)
+        .filter(list -> !list.isEmpty())
+        .map(list -> new ListLectureAPIResponse(list))
+        .orElseThrow(()->new CustomException(ErrorCode.LECTURE_NOT_FOUND));
+  }
+
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCaseImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/in/ListLectureUseCaseImpl.java
@@ -3,14 +3,12 @@ package io.hhplus.lecture_apply_service.application.port.in;
 import io.hhplus.lecture_apply_service.common.UseCase;
 import io.hhplus.lecture_apply_service.exception.CustomException;
 import io.hhplus.lecture_apply_service.exception.ErrorCode;
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
-import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @UseCase
@@ -19,7 +17,7 @@ public class ListLectureUseCaseImpl implements ListLectureUseCase{
 
   @Override
   public ListLectureAPIResponse execute() {
-    List<LectureJpaEntity> lectures = lectureRepository.findAll();
+    List<Lecture> lectures = lectureRepository.findAll();
     return Optional.ofNullable(lectures)
         .filter(list -> !list.isEmpty())
         .map(list -> new ListLectureAPIResponse(list))

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/LectureId.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/LectureId.java
@@ -1,0 +1,25 @@
+package io.hhplus.lecture_apply_service.application.port.out.persistence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@EqualsAndHashCode
+@Embeddable
+public class LectureId implements Serializable {
+  @Column(name = "lecture_id")
+  private Long lectureId;
+
+  @Column(name = "start_at")
+  private LocalDateTime startAt;
+
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/LectureId.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/LectureId.java
@@ -16,10 +16,9 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 @Embeddable
 public class LectureId implements Serializable {
-  @Column(name = "lecture_id")
+  @Column(name = "id")
   private Long lectureId;
 
   @Column(name = "start_at")
   private LocalDateTime startAt;
-
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/StudentLectureId.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/StudentLectureId.java
@@ -3,8 +3,19 @@ package io.hhplus.lecture_apply_service.application.port.out.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@EqualsAndHashCode
 @Embeddable
 public class StudentLectureId implements Serializable {
     @Column(name = "student_id")
@@ -12,11 +23,4 @@ public class StudentLectureId implements Serializable {
 
     @Column(name = "lecture_id")
     private LectureId lectureId;
-    public StudentLectureId() {
-    }
-    // Constructor
-    public StudentLectureId(Long studentId, LectureId lectureId) {
-        this.studentId = studentId;
-        this.lectureId = lectureId;
-    }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/StudentLectureId.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/StudentLectureId.java
@@ -6,16 +6,16 @@ import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 
 @Embeddable
-public class UserLectureId implements Serializable {
+public class StudentLectureId implements Serializable {
     @Column(name = "student_id")
     private Long studentId;
 
     @Column(name = "lecture_id")
-    private Long lectureId;
-    public UserLectureId() {
+    private LectureId lectureId;
+    public StudentLectureId() {
     }
     // Constructor
-    public UserLectureId (Long studentId, Long lectureId) {
+    public StudentLectureId(Long studentId, LectureId lectureId) {
         this.studentId = studentId;
         this.lectureId = lectureId;
     }

--- a/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/UserLectureId.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/application/port/out/persistence/UserLectureId.java
@@ -7,16 +7,16 @@ import java.io.Serializable;
 
 @Embeddable
 public class UserLectureId implements Serializable {
-    @Column(name = "user_id")
-    private Long userId;
+    @Column(name = "student_id")
+    private Long studentId;
 
     @Column(name = "lecture_id")
     private Long lectureId;
     public UserLectureId() {
     }
     // Constructor
-    public UserLectureId (Long userId, Long lectureId) {
-        this.userId = userId;
+    public UserLectureId (Long studentId, Long lectureId) {
+        this.studentId = studentId;
         this.lectureId = lectureId;
     }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     INVALID_TIME(BAD_REQUEST, "특강 신청 기간이 아닙니다."),
 
     //404
-
+    LECTURE_NOT_FOUND(NOT_FOUND, "특강을 찾을 수 없습니다."),
 
     //409
 

--- a/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
@@ -22,8 +22,7 @@ public enum ErrorCode {
 
     //500
 
-    ALREADY_APPLIED(BAD_REQUEST, "해당 특강을 이미 수강하고 있습니다."),
-    INVALID_TIME(BAD_REQUEST,"아직 특강 신청 기간이 아닙니다.");
+    ALREADY_APPLIED(BAD_REQUEST, "해당 특강을 이미 수강하고 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     INVALID_LECTURE_ID(BAD_REQUEST, "유효하지 않은 특강 ID 입니다."),
     INVALID_STUDENT_ID(BAD_REQUEST, "유효하지 않은 학생 ID 입니다."),
+    INVALID_TIME(BAD_REQUEST, "특강 신청 기간이 아닙니다."),
 
     //404
 
@@ -21,7 +22,9 @@ public enum ErrorCode {
 
     //500
 
-    DUMMY(BAD_REQUEST, "Dummy");
+    ALREADY_APPLIED(BAD_REQUEST, "해당 특강을 이미 수강하고 있습니다."),
+    INVALID_TIME(BAD_REQUEST,"아직 특강 신청 기간이 아닙니다.");
+
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
@@ -19,20 +19,19 @@ public class LectureRepositoryImpl implements LectureRepository {
     return lectureRepository.findById(lectureId);
   }
 
+
   @Override
   public Lecture save(Lecture lecture) {
     return lectureRepository.save(lecture);
   }
+
+
 
   @Override
   public Optional<Lecture> findByIdxLock(Long lectureId) {
     return lectureRepository.findByIdxLock(lectureId);
   }
 
-  @Override
-  public Lecture savexLock(Lecture lecture) {
-    return lectureRepository.savexLock(lecture);
-  }
 
   @Override
   public List<Lecture> findAll() {

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
@@ -3,6 +3,7 @@ package io.hhplus.lecture_apply_service.infrastructure;
 import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.LectureJpaRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -31,5 +32,10 @@ public class LectureRepositoryImpl implements LectureRepository {
   @Override
   public LectureJpaEntity savexLock(LectureJpaEntity lecture) {
     return lectureRepository.savexLock(lecture);
+  }
+
+  @Override
+  public List<LectureJpaEntity> findAll() {
+    return lectureRepository.findAll();
   }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
@@ -1,6 +1,6 @@
 package io.hhplus.lecture_apply_service.infrastructure;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.LectureJpaRepository;
 import java.util.List;
@@ -15,27 +15,27 @@ public class LectureRepositoryImpl implements LectureRepository {
   private final LectureJpaRepository lectureRepository;
 
   @Override
-  public Optional<LectureJpaEntity> findById(Long lectureId) {
+  public Optional<Lecture> findById(Long lectureId) {
     return lectureRepository.findById(lectureId);
   }
 
   @Override
-  public LectureJpaEntity save(LectureJpaEntity lecture) {
+  public Lecture save(Lecture lecture) {
     return lectureRepository.save(lecture);
   }
 
   @Override
-  public Optional<LectureJpaEntity> findByIdxLock(Long lectureId) {
+  public Optional<Lecture> findByIdxLock(Long lectureId) {
     return lectureRepository.findByIdxLock(lectureId);
   }
 
   @Override
-  public LectureJpaEntity savexLock(LectureJpaEntity lecture) {
+  public Lecture savexLock(Lecture lecture) {
     return lectureRepository.savexLock(lecture);
   }
 
   @Override
-  public List<LectureJpaEntity> findAll() {
+  public List<Lecture> findAll() {
     return lectureRepository.findAll();
   }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/LectureRepositoryImpl.java
@@ -1,5 +1,6 @@
 package io.hhplus.lecture_apply_service.infrastructure;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.LectureJpaRepository;
@@ -15,9 +16,11 @@ public class LectureRepositoryImpl implements LectureRepository {
   private final LectureJpaRepository lectureRepository;
 
   @Override
-  public Optional<Lecture> findById(Long lectureId) {
+  public Optional<Lecture> findById(LectureId lectureId) {
     return lectureRepository.findById(lectureId);
   }
+
+
 
 
   @Override
@@ -25,10 +28,8 @@ public class LectureRepositoryImpl implements LectureRepository {
     return lectureRepository.save(lecture);
   }
 
-
-
   @Override
-  public Optional<Lecture> findByIdxLock(Long lectureId) {
+  public Optional<Lecture> findByIdxLock(LectureId lectureId) {
     return lectureRepository.findByIdxLock(lectureId);
   }
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
@@ -29,4 +29,8 @@ public class StudentLectureRepositoryImpl implements StudentLectureRepository {
   public List<StudentLecture> findAllByStudentId(Long studentId) {
     return studentLectureRepository.findAllByStudentId(studentId);
   }
+
+  public List<StudentLecture> findAll(){
+    return studentLectureRepository.findAll();
+  }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
@@ -1,5 +1,6 @@
 package io.hhplus.lecture_apply_service.infrastructure;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLectureJpaRepository;
@@ -20,8 +21,9 @@ public class StudentLectureRepositoryImpl implements StudentLectureRepository {
     return studentLectureRepository.save(lecture);
   }
 
+
   @Override
-  public boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId) {
+  public boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, LectureId lectureId) {
     return studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(studentId, lectureId);
   }
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
@@ -1,6 +1,6 @@
 package io.hhplus.lecture_apply_service.infrastructure;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLectureJpaRepository;
 import java.util.List;
@@ -14,7 +14,7 @@ public class StudentLectureRepositoryImpl implements StudentLectureRepository {
   private StudentLectureJpaRepository studentLectureRepository;
 
   @Override
-  public StudentLectureJpaEntity save(StudentLectureJpaEntity lecture) {
+  public StudentLecture save(StudentLecture lecture) {
     return studentLectureRepository.save(lecture);
   }
 
@@ -24,7 +24,7 @@ public class StudentLectureRepositoryImpl implements StudentLectureRepository {
   }
 
   @Override
-  public List<StudentLectureJpaEntity> findAllByStudentId(Long studentId) {
+  public List<StudentLecture> findAllByStudentId(Long studentId) {
     return studentLectureRepository.findAllByStudentId(studentId);
   }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
@@ -6,13 +6,15 @@ import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLect
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Repository
 public class StudentLectureRepositoryImpl implements StudentLectureRepository {
 
-  private StudentLectureJpaRepository studentLectureRepository;
+  private final StudentLectureJpaRepository studentLectureRepository;
 
+  @Transactional
   @Override
   public StudentLecture save(StudentLecture lecture) {
     return studentLectureRepository.save(lecture);

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentLectureRepositoryImpl.java
@@ -3,6 +3,7 @@ package io.hhplus.lecture_apply_service.infrastructure;
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLectureJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -20,5 +21,10 @@ public class StudentLectureRepositoryImpl implements StudentLectureRepository {
   @Override
   public boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId) {
     return studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(studentId, lectureId);
+  }
+
+  @Override
+  public List<StudentLectureJpaEntity> findAllByStudentId(Long studentId) {
+    return studentLectureRepository.findAllByStudentId(studentId);
   }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentRepositoryImpl.java
@@ -20,4 +20,14 @@ public class StudentRepositoryImpl implements StudentRepository {
   public Optional<Student> findById(Long studentId) {
     return studentRepository.findById(studentId);
   }
+
+  @Override
+  public Student save(Student student) {
+    return studentRepository.save(student);
+  }
+
+  @Override
+  public Optional<Student> findByIdxLock(Long studentId) {
+    return studentRepository.findByIdxLock(studentId);
+  }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentRepositoryImpl.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/StudentRepositoryImpl.java
@@ -1,7 +1,7 @@
 package io.hhplus.lecture_apply_service.infrastructure;
 
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentRepository;
 
 import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentJpaRepository;
@@ -17,7 +17,7 @@ public class StudentRepositoryImpl implements StudentRepository {
 
 
   @Override
-  public Optional<StudentJpaEntity> findById(Long studentId) {
+  public Optional<Student> findById(Long studentId) {
     return studentRepository.findById(studentId);
   }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class LectureJpaEntity {
+public class Lecture {
     @Id
     @GeneratedValue (strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,5 +23,5 @@ public class LectureJpaEntity {
     private LocalDateTime open_at;
 
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<StudentLectureJpaEntity> attend = new HashSet<>();
+    private Set<StudentLecture> attend = new HashSet<>();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
@@ -1,7 +1,7 @@
 package io.hhplus.lecture_apply_service.infrastructure.entity;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,16 +12,37 @@ import java.util.Set;
 @Entity
 @Table(name = "lecture")
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class Lecture {
-    @Id
-    @GeneratedValue (strategy = GenerationType.IDENTITY)
-    private Long id;
+
+    @EmbeddedId
+    private LectureId id;
+
+    @Column (name = "tmp_id")
+    private Long tmpId;
+
+    @Column (name = "start_at")
+    private LocalDateTime startAt;
+
+    @Column (name = "name")
     private String name;
+
+    @Column (name = "capacity")
     private Integer capacity;
+    @Column (name = "open_at")
     private LocalDateTime open_at;
+
 
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<StudentLecture> attend = new HashSet<>();
+
+    public Lecture(Long tmpId, LocalDateTime startAt, String name, Integer capacity, LocalDateTime open_at, HashSet attend){
+        this.tmpId = tmpId;
+        this.startAt = startAt;
+        this.name = name;
+        this.capacity = capacity;
+        this.open_at = open_at;
+        this.attend = attend;
+        this.id = new LectureId(tmpId, startAt);
+    }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Lecture.java
@@ -18,12 +18,6 @@ public class Lecture {
     @EmbeddedId
     private LectureId id;
 
-    @Column (name = "tmp_id")
-    private Long tmpId;
-
-    @Column (name = "start_at")
-    private LocalDateTime startAt;
-
     @Column (name = "name")
     private String name;
 
@@ -36,13 +30,11 @@ public class Lecture {
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<StudentLecture> attend = new HashSet<>();
 
-    public Lecture(Long tmpId, LocalDateTime startAt, String name, Integer capacity, LocalDateTime open_at, HashSet attend){
-        this.tmpId = tmpId;
-        this.startAt = startAt;
+    public Lecture(Long lectureId, LocalDateTime startAt, String name, Integer capacity, LocalDateTime open_at, HashSet attend){
         this.name = name;
         this.capacity = capacity;
         this.open_at = open_at;
         this.attend = attend;
-        this.id = new LectureId(tmpId, startAt);
+        this.id = new LectureId(lectureId, startAt);
     }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Student.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/Student.java
@@ -13,12 +13,12 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class StudentJpaEntity {
+public class Student {
     @Id
     @GeneratedValue (strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
 
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<StudentLectureJpaEntity> apply = new HashSet<>();
+    private Set<StudentLecture> apply = new HashSet<>();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
@@ -1,6 +1,7 @@
 package io.hhplus.lecture_apply_service.infrastructure.entity;
 
-import io.hhplus.lecture_apply_service.application.port.out.persistence.UserLectureId;
+import io.hhplus.lecture_apply_service.application.port.out.persistence.StudentLectureId;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StudentLecture {
     @EmbeddedId
-    private UserLectureId id;
+    private StudentLectureId id;
 
     @ManyToOne
     @JoinColumn(name = "student_id", referencedColumnName = "id", insertable = false, updatable = false)
@@ -28,7 +29,7 @@ public class StudentLecture {
     public StudentLecture(Student student, Lecture lecture, Boolean enrollment){
         this.student = student;
         this.lecture = lecture;
-        this.id = new UserLectureId(student.getId(), lecture.getId());
+        this.id = new StudentLectureId(student.getId(), lecture.getId());
         this.enrollment = enrollment;
     }
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
@@ -11,21 +11,21 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class StudentLectureJpaEntity {
+public class StudentLecture {
     @EmbeddedId
     private UserLectureId id;
 
     @ManyToOne
     @JoinColumn(name = "student_id", referencedColumnName = "id", insertable = false, updatable = false)
-    private StudentJpaEntity student;
+    private Student student;
 
     @ManyToOne
     @JoinColumn(name = "lecture_id", referencedColumnName = "id", insertable = false, updatable = false)
-    private LectureJpaEntity lecture;
+    private Lecture lecture;
 
     private Boolean enrollment;
 
-    public StudentLectureJpaEntity(StudentJpaEntity student, LectureJpaEntity lecture, Boolean enrollment){
+    public StudentLecture(Student student, Lecture lecture, Boolean enrollment){
         this.student = student;
         this.lecture = lecture;
         this.id = new UserLectureId(student.getId(), lecture.getId());

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/entity/StudentLecture.java
@@ -13,15 +13,19 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StudentLecture {
-    @EmbeddedId
-    private StudentLectureId id;
+
+  @EmbeddedId
+  private StudentLectureId id;
 
     @ManyToOne
     @JoinColumn(name = "student_id", referencedColumnName = "id", insertable = false, updatable = false)
     private Student student;
 
     @ManyToOne
-    @JoinColumn(name = "lecture_id", referencedColumnName = "id", insertable = false, updatable = false)
+    @JoinColumns({
+        @JoinColumn(name = "lecture_id", referencedColumnName = "id", insertable = false, updatable = false),
+        @JoinColumn(name = "start_at", referencedColumnName = "start_at", insertable = false, updatable = false),
+    })
     private Lecture lecture;
 
     private Boolean enrollment;

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
@@ -1,15 +1,16 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import java.util.List;
 import java.util.Optional;
 
 public interface LectureRepository {
 
-    Optional<Lecture> findById(Long lectureId);
+    Optional<Lecture> findById(LectureId lectureId);
     Lecture save (Lecture lecture);
 
-    Optional<Lecture> findByIdxLock(Long lectureId);
+    Optional<Lecture> findByIdxLock(LectureId lectureId);
 
 
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
@@ -11,7 +11,7 @@ public interface LectureRepository {
 
     Optional<Lecture> findByIdxLock(Long lectureId);
 
-    Lecture savexLock(Lecture lectureJpaEntity);
+
 
     List<Lecture> findAll();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
@@ -1,6 +1,7 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
 import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import java.util.List;
 import java.util.Optional;
 
 public interface LectureRepository {
@@ -11,4 +12,6 @@ public interface LectureRepository {
     Optional<LectureJpaEntity> findByIdxLock(Long lectureId);
 
     LectureJpaEntity savexLock(LectureJpaEntity lectureJpaEntity);
+
+    List<LectureJpaEntity> findAll();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/LectureRepository.java
@@ -1,17 +1,17 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import java.util.List;
 import java.util.Optional;
 
 public interface LectureRepository {
 
-    Optional<LectureJpaEntity> findById(Long lectureId);
-    LectureJpaEntity save (LectureJpaEntity lecture);
+    Optional<Lecture> findById(Long lectureId);
+    Lecture save (Lecture lecture);
 
-    Optional<LectureJpaEntity> findByIdxLock(Long lectureId);
+    Optional<Lecture> findByIdxLock(Long lectureId);
 
-    LectureJpaEntity savexLock(LectureJpaEntity lectureJpaEntity);
+    Lecture savexLock(Lecture lectureJpaEntity);
 
-    List<LectureJpaEntity> findAll();
+    List<Lecture> findAll();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
@@ -1,11 +1,12 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import java.util.List;
 public interface StudentLectureRepository {
   StudentLecture save (StudentLecture lecture);
 
-  boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
+  boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, LectureId lectureId);
 
   List<StudentLecture> findAllByStudentId(Long studentId);
 

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
@@ -1,9 +1,11 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
-
+import java.util.List;
 public interface StudentLectureRepository {
   StudentLectureJpaEntity save (StudentLectureJpaEntity lecture);
 
   boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
+
+  List<StudentLectureJpaEntity> findAllByStudentId(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
@@ -8,4 +8,6 @@ public interface StudentLectureRepository {
   boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
 
   List<StudentLecture> findAllByStudentId(Long studentId);
+
+  List<StudentLecture> findAll();
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentLectureRepository.java
@@ -1,11 +1,11 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import java.util.List;
 public interface StudentLectureRepository {
-  StudentLectureJpaEntity save (StudentLectureJpaEntity lecture);
+  StudentLecture save (StudentLecture lecture);
 
   boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
 
-  List<StudentLectureJpaEntity> findAllByStudentId(Long studentId);
+  List<StudentLecture> findAllByStudentId(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentRepository.java
@@ -5,4 +5,8 @@ import java.util.Optional;
 
 public interface StudentRepository {
   Optional<Student> findById(Long studentId);
+
+  Student save(Student student);
+
+  Optional<Student> findByIdxLock(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/StudentRepository.java
@@ -1,8 +1,8 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
 import java.util.Optional;
 
 public interface StudentRepository {
-  Optional<StudentJpaEntity> findById(Long studentId);
+  Optional<Student> findById(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
@@ -4,6 +4,7 @@ import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -17,8 +18,4 @@ public interface LectureJpaRepository extends JpaRepository<Lecture, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT l FROM Lecture l WHERE l.id = :lectureId")
     Optional<Lecture> findByIdxLock(Long lectureId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("UPDATE Lecture l SET l.name = :#{#Lecture.name}, l.capacity = :#{#Lecture.capacity} WHERE l.id = :#{#Lecture.id}")
-    Lecture savexLock(@Param("Lecture") Lecture Lecture);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
@@ -1,6 +1,6 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,16 +9,16 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 import org.springframework.data.repository.query.Param;
 
-public interface LectureJpaRepository extends JpaRepository<LectureJpaEntity, Long> {
+public interface LectureJpaRepository extends JpaRepository<Lecture, Long> {
 
 
-    Optional<LectureJpaEntity> findById (Long id);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT l FROM LectureJpaEntity l WHERE l.id = :lectureId")
-    Optional<LectureJpaEntity> findByIdxLock(Long lectureId);
+    Optional<Lecture> findById (Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("UPDATE LectureJpaEntity l SET l.name = :#{#lectureJpaEntity.name}, l.capacity = :#{#lectureJpaEntity.capacity} WHERE l.id = :#{#lectureJpaEntity.id}")
-    LectureJpaEntity savexLock(@Param("lectureJpaEntity") LectureJpaEntity lectureJpaEntity);
+    @Query("SELECT l FROM Lecture l WHERE l.id = :lectureId")
+    Optional<Lecture> findByIdxLock(Long lectureId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("UPDATE Lecture l SET l.name = :#{#Lecture.name}, l.capacity = :#{#Lecture.capacity} WHERE l.id = :#{#Lecture.id}")
+    Lecture savexLock(@Param("Lecture") Lecture Lecture);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/LectureJpaRepository.java
@@ -1,21 +1,20 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
+
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
-import org.springframework.data.repository.query.Param;
-
-public interface LectureJpaRepository extends JpaRepository<Lecture, Long> {
+import org.springframework.data.repository.query.Param;public interface LectureJpaRepository extends JpaRepository<Lecture, LectureId> {
 
 
-    Optional<Lecture> findById (Long id);
+    Optional<Lecture> findById (LectureId id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT l FROM Lecture l WHERE l.id = :lectureId")
-    Optional<Lecture> findByIdxLock(Long lectureId);
+    Optional<Lecture> findByIdxLock(LectureId lectureId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentJpaRepository.java
@@ -1,9 +1,19 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface StudentJpaRepository extends JpaRepository<Student, Long> {
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT s FROM Student s WHERE s.id = :studentId")
+  Optional<Student> findByIdxLock(Long studentId);
+
+
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentJpaRepository.java
@@ -1,13 +1,9 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
-import jakarta.persistence.LockModeType;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
 
-public interface StudentJpaRepository extends JpaRepository<StudentJpaEntity, Long> {
+public interface StudentJpaRepository extends JpaRepository<Student, Long> {
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
@@ -1,15 +1,14 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
-import jakarta.persistence.LockModeType;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
+
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
-public interface StudentLectureJpaRepository extends JpaRepository<StudentLectureJpaEntity, Long> {
+public interface StudentLectureJpaRepository extends JpaRepository<StudentLecture, Long> {
 
 
   boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
 
-  List<StudentLectureJpaEntity> findAllByStudentId(Long studentId);
+  List<StudentLecture> findAllByStudentId(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
@@ -1,14 +1,16 @@
 package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
+import io.hhplus.lecture_apply_service.application.port.out.persistence.StudentLectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudentLectureJpaRepository extends JpaRepository<StudentLecture, Long> {
+public interface StudentLectureJpaRepository extends JpaRepository<StudentLecture, StudentLectureId> {
 
 
-  boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
+  boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, LectureId lectureId);
 
   List<StudentLecture> findAllByStudentId(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/infrastructure/repository/jpa/StudentLectureJpaRepository.java
@@ -2,6 +2,7 @@ package io.hhplus.lecture_apply_service.infrastructure.repository.jpa;
 
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLectureJpaEntity;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
@@ -9,4 +10,6 @@ public interface StudentLectureJpaRepository extends JpaRepository<StudentLectur
 
 
   boolean existsByStudentIdAndLectureIdAndEnrollmentIsTrue(Long studentId, Long lectureId);
+
+  List<StudentLectureJpaEntity> findAllByStudentId(Long studentId);
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
@@ -41,15 +41,17 @@ public class LectureController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping
+    public ResponseEntity<ListLectureAPIResponse> listLecture(){
+        ListLectureAPIResponse response = listLectureUseCase.execute();
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/application/{userId}")
     public ResponseEntity<EnrolledLectureAPIResponse> checkLectureEnrollment(@PathVariable Long userId) {
         EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(userId);
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping
-    public ResponseEntity<ListLectureAPIResponse> listLecture(){
-        ListLectureAPIResponse response = listLectureUseCase.execute();
-        return ResponseEntity.ok(response);
-    }
+
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
@@ -1,11 +1,14 @@
 package io.hhplus.lecture_apply_service.presentation.dto;
 
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/lectures")
 public class LectureController {
 
+    private final ListLectureUseCase listLectureUseCase;
     public final ApplyLectureUseCase applyLectureUseCase;
+
 
     @PostMapping("/apply")
     public ResponseEntity<ApplyLectureAPIResponse> applyLecture (@RequestBody ApplyLectureAPIRequest request)
@@ -28,6 +33,12 @@ public class LectureController {
 
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
         //ApplyLectureAPIResponse response = new ApplyLectureAPIResponse(true);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ListLectureAPIResponse> listLecture(){
+        ListLectureAPIResponse response = listLectureUseCase.execute();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/LectureController.java
@@ -1,14 +1,18 @@
 package io.hhplus.lecture_apply_service.presentation.dto;
 
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,19 +24,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class LectureController {
 
     private final ListLectureUseCase listLectureUseCase;
-    public final ApplyLectureUseCase applyLectureUseCase;
+    private final ApplyLectureUseCase applyLectureUseCase;
+    private final EnrolledLectureUseCase checkLectureEnrollmentUseCase;
 
 
     @PostMapping("/apply")
     public ResponseEntity<ApplyLectureAPIResponse> applyLecture (@RequestBody ApplyLectureAPIRequest request)
     {
         ApplyLectureCommand command = ApplyLectureCommand.builder()
-                .studentId(request.userId())
+                .studentId(request.studentId())
                 .lectureId(request.lectureId())
                 .build();
 
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
         //ApplyLectureAPIResponse response = new ApplyLectureAPIResponse(true);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/application/{userId}")
+    public ResponseEntity<EnrolledLectureAPIResponse> checkLectureEnrollment(@PathVariable Long userId) {
+        EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ApplyLectureAPIRequest.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ApplyLectureAPIRequest.java
@@ -1,7 +1,13 @@
 package io.hhplus.lecture_apply_service.presentation.dto.req;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import java.time.LocalDateTime;
+
 public record ApplyLectureAPIRequest(
         long studentId,
-        long lectureId
+        long lectureId,
+        LocalDateTime startAt,
+        LocalDateTime requestAt
 ) {
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ApplyLectureAPIRequest.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ApplyLectureAPIRequest.java
@@ -1,7 +1,7 @@
 package io.hhplus.lecture_apply_service.presentation.dto.req;
 
 public record ApplyLectureAPIRequest(
-        long userId,
+        long studentId,
         long lectureId
 ) {
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ListLectureAPIRequest.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/req/ListLectureAPIRequest.java
@@ -1,0 +1,8 @@
+package io.hhplus.lecture_apply_service.presentation.dto.req;
+
+public record ListLectureAPIRequest (
+    boolean available
+) {
+
+
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ApplyLectureAPIResponse.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ApplyLectureAPIResponse.java
@@ -3,5 +3,5 @@ package io.hhplus.lecture_apply_service.presentation.dto.res;
 public record ApplyLectureAPIResponse(
         long studentId,
         long lectureId,
-        boolean success) {
+        boolean status) {
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ApplyLectureAPIResponse.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ApplyLectureAPIResponse.java
@@ -1,7 +1,12 @@
 package io.hhplus.lecture_apply_service.presentation.dto.res;
 
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
+import java.time.LocalDateTime;
+
+
 public record ApplyLectureAPIResponse(
         long studentId,
         long lectureId,
+        LocalDateTime startAt,
         boolean status) {
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/EnrolledLectureAPIResponse.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/EnrolledLectureAPIResponse.java
@@ -1,0 +1,11 @@
+package io.hhplus.lecture_apply_service.presentation.dto.res;
+
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
+import java.util.List;
+
+public record EnrolledLectureAPIResponse (
+    List<StudentLecture> enrolledLectures,
+    boolean status
+){
+
+}

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ListLectureAPIResponse.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ListLectureAPIResponse.java
@@ -1,9 +1,9 @@
 package io.hhplus.lecture_apply_service.presentation.dto.res;
 
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import java.util.List;
 
 public record ListLectureAPIResponse
-    (List<LectureJpaEntity> lectures){
+    (List<Lecture> lectures){
 
 }

--- a/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ListLectureAPIResponse.java
+++ b/src/main/java/io/hhplus/lecture_apply_service/presentation/dto/res/ListLectureAPIResponse.java
@@ -1,0 +1,9 @@
+package io.hhplus.lecture_apply_service.presentation.dto.res;
+
+import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import java.util.List;
+
+public record ListLectureAPIResponse
+    (List<LectureJpaEntity> lectures){
+
+}

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
@@ -25,11 +25,10 @@ import static org.mockito.Mockito.when;
 
 public class ApplyLectureUseCaseTest {
 
-    private final LectureLock lectureLock = Mockito.mock(LectureLock.class);
     private final LectureRepository lectureRepository = Mockito.mock(LectureRepository.class);
     private final StudentRepository studentRepository = Mockito.mock(StudentRepository.class);
     private final StudentLectureRepository studentLectureRepository = Mockito.mock(StudentLectureRepository.class);
-    private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureLock, lectureRepository, studentRepository, studentLectureRepository);
+    private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureRepository, studentRepository, studentLectureRepository);
 
     @Test
     @DisplayName("특강 신청 성공")

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
@@ -1,0 +1,74 @@
+package io.hhplus.lecture_apply_service.domain.lecture.application.service;
+
+import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCaseImpl;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
+import io.hhplus.lecture_apply_service.application.port.out.LectureLock;
+import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentRepository;
+
+import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLectureJpaRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class ApplyLectureUseCaseTest {
+
+    private final LectureLock lectureLock = Mockito.mock(LectureLock.class);
+    private final LectureRepository lectureRepository = Mockito.mock(LectureRepository.class);
+    private final StudentRepository studentRepository = Mockito.mock(StudentRepository.class);
+    private final StudentLectureRepository studentLectureRepository = Mockito.mock(StudentLectureRepository.class);
+    private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureLock, lectureRepository, studentRepository, studentLectureRepository);
+
+    @Test
+    @DisplayName("특강 신청 성공")
+    void applyLectureServicestatus() {
+        //given
+        long studentId = 21L;
+        long lectureId = 100L;
+        ApplyLectureCommand command = ApplyLectureCommand.builder()
+                .studentId(studentId)
+                .lectureId(lectureId)
+                .build();
+        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        Student student = new Student(studentId, "정현우", new HashSet<>());
+
+        //when
+        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
+        ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
+
+        //then
+        assertThat(response.status()).isTrue();
+    }
+
+    @Test
+    @DisplayName("특강 신청 실패")
+    void applyLectureServiceFail() {
+
+        long studentId = 21L;
+        long lectureId = 100L;
+        ApplyLectureCommand command = ApplyLectureCommand.builder()
+                .studentId(studentId)
+                .lectureId(lectureId)
+                .build();
+        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        Student student = new Student(studentId, "정현우", new HashSet<>());
+        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
+
+        ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
+        assertThat(response.status()).isFalse();
+    }
+}

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/service/ApplyLectureUseCaseTest.java
@@ -40,11 +40,12 @@ public class ApplyLectureUseCaseTest {
                 .studentId(studentId)
                 .lectureId(lectureId)
                 .build();
-        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        LocalDateTime localDateTime = LocalDateTime.now();
+        Lecture lecture = new Lecture(lectureId, localDateTime, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
         Student student = new Student(studentId, "정현우", new HashSet<>());
 
         //when
-        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+        when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
         when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
 
@@ -62,9 +63,10 @@ public class ApplyLectureUseCaseTest {
                 .studentId(studentId)
                 .lectureId(lectureId)
                 .build();
-        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        LocalDateTime localDateTime = LocalDateTime.now();
+        Lecture lecture = new Lecture(lectureId, localDateTime, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
         Student student = new Student(studentId, "정현우", new HashSet<>());
-        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+        when(lectureRepository.findById(lecture.getId())).thenReturn(Optional.of(lecture));
         when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
 
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
@@ -66,7 +66,7 @@ public class ApplyLectureUseCaseTest {
         ApplyLectureCommand command = ApplyLectureCommand.builder()
             .studentId(student.getId())
             .lectureId(lecture.getId().getLectureId())
-            .startAt(lecture.getStartAt())
+            .startAt(lecture.getId().getStartAt())
             .requestAt(LocalDateTime.now())
             .build();
 
@@ -102,7 +102,7 @@ public class ApplyLectureUseCaseTest {
         ApplyLectureCommand command = ApplyLectureCommand.builder()
             .studentId(student.getId())
             .lectureId(lecture.getId().getLectureId())
-            .startAt(lecture.getStartAt())
+            .startAt(lecture.getId().getStartAt())
             .requestAt(LocalDateTime.now())
             .build();
 
@@ -135,7 +135,7 @@ public class ApplyLectureUseCaseTest {
         ApplyLectureCommand command = ApplyLectureCommand.builder()
                 .studentId(student.getId())
                 .lectureId(lecture.getId().getLectureId())
-            .startAt(lecture.getStartAt())
+            .startAt(lecture.getId().getStartAt())
             .requestAt(LocalDateTime.now())
                 .build();
         when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
@@ -178,7 +178,7 @@ public class ApplyLectureUseCaseTest {
             ApplyLectureCommand command = ApplyLectureCommand.builder()
                     .studentId(i)
                     .lectureId(lectureId)
-                .startAt(lecture.getStartAt())
+                .startAt(lecture.getId().getStartAt())
                 .requestAt(LocalDateTime.now())
                     .build();
 
@@ -219,7 +219,7 @@ public class ApplyLectureUseCaseTest {
                 ApplyLectureCommand command = ApplyLectureCommand.builder()
                         .studentId(student.getId())
                         .lectureId(lecture.getId().getLectureId())
-                    .startAt(lecture.getStartAt())
+                    .startAt(lecture.getId().getStartAt())
                     .requestAt(LocalDateTime.now())
                         .build();
                 when(studentRepository.findById(anyLong())).thenReturn(Optional.of(student));

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
@@ -2,16 +2,16 @@ package io.hhplus.lecture_apply_service.domain.lecture.application.useCase;
 
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCaseImpl;
-
-import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
-import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import io.hhplus.lecture_apply_service.exception.CustomException;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
 import io.hhplus.lecture_apply_service.application.port.out.LectureLock;
+
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentRepository;
-
-import io.hhplus.lecture_apply_service.infrastructure.repository.jpa.StudentLectureJpaRepository;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,8 +25,11 @@ import java.util.Optional;
 import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ApplyLectureUseCaseTest {
@@ -36,80 +39,110 @@ public class ApplyLectureUseCaseTest {
     private final StudentLectureRepository studentLectureRepository = Mockito.mock(StudentLectureRepository.class);
     private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureRepository, studentRepository, studentLectureRepository);
 
+    private List<Student> students;
+    private List<Lecture> lectures;
+
     @Test
     @DisplayName("특강 신청 성공")
-    void applyLectureServicestatus() {
+    void applyLectureServiceSuccess() {
         //given
-        long studentId = 21L;
-        long lectureId = 100L;
+        Student student = students.get(0);
+        Lecture lecture = lectures.get(1); //정원이 1명 남은 특강
+
         ApplyLectureCommand command = ApplyLectureCommand.builder()
-                .studentId(studentId)
-                .lectureId(lectureId)
-                .build();
-        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
-        Student student = new Student(studentId, "정현우", new HashSet<>());
+            .studentId(student.getId())
+            .lectureId(lecture.getId())
+            .build();
+
 
         //when
-        when(lectureRepository.findByIdxLock(lectureId)).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
+        when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
 
         //then
         assertThat(response.status()).isTrue();
+        //성공 히스토리 기록했는지 확인
+        verify(studentLectureRepository, times(1)).save(any(StudentLecture.class));
     }
 
     @Test
-    @DisplayName("특강 신청 실패")
+    @DisplayName("이미 수강한 특강을 다시 신청한 경우")
+    void applyLectureAlreadyApplied() {
+        Student student = students.get(0);
+        Lecture lecture = lectures.get(28);
+
+        ApplyLectureCommand command = ApplyLectureCommand.builder()
+            .studentId(student.getId())
+            .lectureId(lecture.getId())
+            .build();
+
+        when(studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(student.getId(), lecture.getId())).thenReturn(true);
+        when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
+
+        CustomException studentException = assertThrows(CustomException.class, ()->applyLectureUseCase.execute(command));
+        assertThat(studentException.getErrorCode().name()).isEqualTo("ALREADY_APPLIED");
+    }
+
+    @Test
+    @DisplayName("수강 인원 초과, 특강 신청 실패")
     void applyLectureServiceFail() {
 
-        long studentId = 21L;
-        long lectureId = 100L;
+        //given
+        Student student = students.get(0);
+        Lecture lecture = lectures.get(0);
         ApplyLectureCommand command = ApplyLectureCommand.builder()
-                .studentId(studentId)
-                .lectureId(lectureId)
+                .studentId(student.getId())
+                .lectureId(lecture.getId())
                 .build();
-        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
-        Student student = new Student(studentId, "정현우", new HashSet<>());
-        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
+        when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(student.getId(), lecture.getId())).thenReturn(false);
 
+        //when
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
+
+        //then
+        StudentLecture studentLecture = new StudentLecture(student, lecture, false);
+        //실패 히스토리 기록 했는지 확인
+        verify(studentLectureRepository, times(1)).save(any(StudentLecture.class));
         assertThat(response.status()).isFalse();
+
     }
 
     @Test
     @DisplayName("특강 신청 동시성 테스트 : 동시적이 아닌 순차적으로 실행")
     void applyLectureServiceSequential() throws InterruptedException {
         //given
-        long userId = 1L;
+        long studentId = 1L;
         long lectureId = 10L;
         int trial = 36;
 
         ExecutorService executorService =Executors.newFixedThreadPool(trial);
         CountDownLatch latch = new CountDownLatch(trial);
         List<Future<ApplyLectureAPIResponse>> futures = new ArrayList<>();
-        LectureJpaEntity lecture = new LectureJpaEntity(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
 
         //when
-        when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
-        when(userRepository.findById(anyLong())).thenAnswer(invocation ->{
+        when(lectureRepository.findByIdxLock(lectureId)).thenReturn(Optional.of(lecture));
+        when(studentRepository.findById(anyLong())).thenAnswer(invocation ->{
             long id = invocation.getArgument(0);
-            return Optional.of(new StudentJpaEntity(id, "정현우"+id, new HashSet<>()));
+            return Optional.of(new Student(id, "정현우"+id, new HashSet<>()));
         });
-        when(lectureRepository.save(any(LectureJpaEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        long longTrial = (long) trial;
-        for (long i = userId; i < userId + longTrial; ++i){
+        when(lectureRepository.save(any(Lecture.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        for (long i = studentId; i < studentId + trial; ++i){
             ApplyLectureCommand command = ApplyLectureCommand.builder()
-                    .userId(i)
+                    .studentId(i)
                     .lectureId(lectureId)
                     .build();
 
             ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
-            if (response.userId() >= userId + 30){
-                assertThat(response.success()).isFalse();
+            if (response.studentId() >= studentId + 30){
+                assertThat(response.status()).isFalse();
             }
             else {
-                assertThat(response.success()).isTrue();
+                assertThat(response.status()).isTrue();
             }
         }
     }
@@ -118,26 +151,26 @@ public class ApplyLectureUseCaseTest {
     @DisplayName("특강 신청 동시성 테스트 : 31명 부터는 실패")
     void applyLectureServiceConcurrency() throws InterruptedException {
         //given
-        long userId = 1L;
+        long studentId = 1L;
         long lectureId = 10L;
         int trial = 40;
 
         ExecutorService executorService =Executors.newFixedThreadPool(trial);
         CountDownLatch latch = new CountDownLatch(trial);
         List<Future<ApplyLectureAPIResponse>> futures = new ArrayList<>();
-        LectureJpaEntity lecture = new LectureJpaEntity(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 30, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
 
         //when
         when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
-        when(userRepository.findById(anyLong())).thenAnswer(invocation ->{
+        when(studentRepository.findById(anyLong())).thenAnswer(invocation ->{
             long id = invocation.getArgument(0);
-            return Optional.of(new StudentJpaEntity(id, "정현우"+id, new HashSet<>()));
+            return Optional.of(new Student(id, "정현우"+id, new HashSet<>()));
         });
-        when(lectureRepository.save(any(LectureJpaEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(lectureRepository.save(any(Lecture.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        for (long i = userId; i < userId + trial; ++i){
+        for (long i = studentId; i < studentId + trial; ++i){
             ApplyLectureCommand command = ApplyLectureCommand.builder()
-                    .userId(i)
+                    .studentId(i)
                     .lectureId(lectureId)
                     .build();
 
@@ -150,12 +183,12 @@ public class ApplyLectureUseCaseTest {
         futures.stream().forEach(future ->{
             try {
                 ApplyLectureAPIResponse response = future.get();
-                System.out.println(response.userId());
-                if (response.userId() >= userId + 30){
-                    assertThat(response.success()).isFalse();
+                System.out.println(response.studentId());
+                if (response.studentId() >= studentId + 30){
+                    assertThat(response.status()).isFalse();
                 }
                 else {
-                    assertThat(response.success()).isTrue();
+                    assertThat(response.status()).isTrue();
                 }
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
@@ -172,28 +205,28 @@ public class ApplyLectureUseCaseTest {
     @DisplayName("특강 신청 동시성 30명")
     void applyLectureServiceConcurrencySecond() throws InterruptedException {
 
-        long userId = 21L;
+        long studentId = 21L;
         long lectureId = 10L;
 
         int trial = 30;
 
-        List<StudentJpaEntity> users = new ArrayList<>();
-        for (long i = userId; i < userId + trial; ++i){
-            users.add(new StudentJpaEntity(i, "정현우"+i, new HashSet<>()));
+        List<Student> students = new ArrayList<>();
+        for (long i = studentId; i < studentId + trial; ++i){
+            students.add(new Student(i, "정현우"+i, new HashSet<>()));
         }
-        LectureJpaEntity lecture = new LectureJpaEntity(lectureId, "클린아키텍처", 0, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
+        Lecture lecture = new Lecture(lectureId, "클린아키텍처", 0, LocalDateTime.of(2024,4,27,13,0), new HashSet<>());
 
         when(lectureRepository.findById(anyLong())).thenReturn(Optional.of(lecture));
 
 
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (StudentJpaEntity user : users){
+        for (Student student : students){
             CompletableFuture<Void> future = CompletableFuture.runAsync(()->{
                 ApplyLectureCommand command = ApplyLectureCommand.builder()
-                        .userId(user.getId())
+                        .studentId(student.getId())
                         .lectureId(lectureId)
                         .build();
-                when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+                when(studentRepository.findById(anyLong())).thenReturn(Optional.of(student));
                 applyLectureUseCase.execute(command);
             });
             futures.add(future);

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 public class ApplyLectureUseCaseTest {
 
+
     private final LectureRepository lectureRepository = Mockito.mock(LectureRepository.class);
     private final StudentRepository studentRepository = Mockito.mock(StudentRepository.class);
     private final StudentLectureRepository studentLectureRepository = Mockito.mock(StudentLectureRepository.class);
@@ -57,7 +58,7 @@ public class ApplyLectureUseCaseTest {
 
         //when
         when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(studentRepository.findByIdxLock(student.getId())).thenReturn(Optional.of(student));
         ApplyLectureAPIResponse response = applyLectureUseCase.execute(command);
 
         //then
@@ -79,7 +80,7 @@ public class ApplyLectureUseCaseTest {
 
         when(studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(student.getId(), lecture.getId())).thenReturn(true);
         when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(studentRepository.findByIdxLock(student.getId())).thenReturn(Optional.of(student));
 
         CustomException studentException = assertThrows(CustomException.class, ()->applyLectureUseCase.execute(command));
         assertThat(studentException.getErrorCode().name()).isEqualTo("ALREADY_APPLIED");
@@ -97,7 +98,7 @@ public class ApplyLectureUseCaseTest {
                 .lectureId(lecture.getId())
                 .build();
         when(lectureRepository.findByIdxLock(lecture.getId())).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(studentRepository.findByIdxLock(student.getId())).thenReturn(Optional.of(student));
         when(studentLectureRepository.existsByStudentIdAndLectureIdAndEnrollmentIsTrue(student.getId(), lecture.getId())).thenReturn(false);
 
         //when
@@ -126,7 +127,7 @@ public class ApplyLectureUseCaseTest {
 
         //when
         when(lectureRepository.findByIdxLock(lectureId)).thenReturn(Optional.of(lecture));
-        when(studentRepository.findById(anyLong())).thenAnswer(invocation ->{
+        when(studentRepository.findByIdxLock(anyLong())).thenAnswer(invocation ->{
             long id = invocation.getArgument(0);
             return Optional.of(new Student(id, "정현우"+id, new HashSet<>()));
         });
@@ -226,7 +227,7 @@ public class ApplyLectureUseCaseTest {
                         .studentId(student.getId())
                         .lectureId(lectureId)
                         .build();
-                when(studentRepository.findById(anyLong())).thenReturn(Optional.of(student));
+                when(studentRepository.findByIdxLock(anyLong())).thenReturn(Optional.of(student));
                 applyLectureUseCase.execute(command);
             });
             futures.add(future);

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ApplyLectureUseCaseTest.java
@@ -31,11 +31,10 @@ import static org.mockito.Mockito.when;
 
 public class ApplyLectureUseCaseTest {
 
-    private final LectureLock lectureLock = Mockito.mock(LectureLock.class);
     private final LectureRepository lectureRepository = Mockito.mock(LectureRepository.class);
     private final StudentRepository studentRepository = Mockito.mock(StudentRepository.class);
     private final StudentLectureRepository studentLectureRepository = Mockito.mock(StudentLectureRepository.class);
-    private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureLock, lectureRepository, studentRepository, studentLectureRepository);
+    private final ApplyLectureUseCase applyLectureUseCase = new ApplyLectureUseCaseImpl(lectureRepository, studentRepository, studentLectureRepository);
 
     @Test
     @DisplayName("특강 신청 성공")

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
@@ -6,6 +6,7 @@ import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
 import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
 import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
 import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -42,7 +43,9 @@ public class EnrolledLectureUseCaseTest {
       students.add(student);
     }
     for (int i=1; i < 35; ++i){
-      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      LocalDateTime localDateTime = LocalDateTime.now();
+
+      Lecture lecture = new Lecture((long)i,localDateTime, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
       lectures.add(lecture);
     }
     for (int i = 0; i < 10; ++i){

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
@@ -1,0 +1,81 @@
+package io.hhplus.lecture_apply_service.domain.lecture.application.useCase;
+
+import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCaseImpl;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EnrolledLectureUseCaseTest {
+  private final StudentLectureRepository studentLectureRepository = Mockito.mock(
+      StudentLectureRepository.class);
+  private EnrolledLectureUseCase checkLectureEnrollmentUseCase = new EnrolledLectureUseCaseImpl(studentLectureRepository);
+
+  private List<StudentJpaEntity> students;
+  private List<LectureJpaEntity> lectures;
+  private List<StudentLectureJpaEntity> studentLectures;
+
+  @BeforeEach
+  void setUp() {
+    students = new ArrayList<>();
+    lectures = new ArrayList<>();
+    studentLectures = new ArrayList<>();
+
+    for (int i = 1; i < 40; ++i) {
+      StudentJpaEntity student = new StudentJpaEntity((long) i, "정현우" + i, new HashSet<>());
+      students.add(student);
+    }
+    for (int i=1; i < 35; ++i){
+      LectureJpaEntity lecture = new LectureJpaEntity((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+    }
+    for (int i = 0; i < 10; ++i){
+      StudentLectureJpaEntity studentLecture = new StudentLectureJpaEntity(students.get(i), lectures.get(i), i % 2 == 0);
+      studentLectures.add(studentLecture);
+    }
+  }
+  @Test
+  @DisplayName("강의 신청 완료 여부 확인 테스트, 수강 성공")
+  public void checkLectureEnrollment_success() {
+    //Given
+    StudentJpaEntity student = students.get(5);
+    List<StudentLectureJpaEntity> filtered = studentLectures.stream()
+            .filter(studentLecture -> studentLecture.getStudent().getId().equals(student.getId()))
+            .collect(Collectors.toList());
+
+    when(studentLectureRepository.findAllByStudentId(student.getId())).thenReturn(filtered);
+
+    EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(student.getId());
+    assertThat(response.enrolledLectures()).isNotEmpty();
+    assertThat(response.status()).isTrue();
+    verify(studentLectureRepository, times(1)).findAllByStudentId(student.getId());
+  }
+
+  @Test
+  @DisplayName("강의 신청 완료 여부 확인 테스트, 수강 실패")
+  public void checkLectureEnrollment_fail() {
+    //Given
+    StudentJpaEntity student = students.get(2);
+    when(studentLectureRepository.findAllByStudentId(student.getId())).thenReturn(List.of());
+
+    EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(student.getId());
+    assertThat(response.status()).isFalse();
+    verify(studentLectureRepository, times(1)).findAllByStudentId(student.getId());
+  }
+}

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/EnrolledLectureUseCaseTest.java
@@ -25,11 +25,11 @@ import static org.mockito.Mockito.when;
 public class EnrolledLectureUseCaseTest {
   private final StudentLectureRepository studentLectureRepository = Mockito.mock(
       StudentLectureRepository.class);
-  private EnrolledLectureUseCase checkLectureEnrollmentUseCase = new EnrolledLectureUseCaseImpl(studentLectureRepository);
+  private EnrolledLectureUseCase enrolledLectureUseCase = new EnrolledLectureUseCaseImpl(studentLectureRepository);
 
-  private List<StudentJpaEntity> students;
-  private List<LectureJpaEntity> lectures;
-  private List<StudentLectureJpaEntity> studentLectures;
+  private List<Student> students;
+  private List<Lecture> lectures;
+  private List<StudentLecture> studentLectures;
 
   @BeforeEach
   void setUp() {
@@ -38,15 +38,15 @@ public class EnrolledLectureUseCaseTest {
     studentLectures = new ArrayList<>();
 
     for (int i = 1; i < 40; ++i) {
-      StudentJpaEntity student = new StudentJpaEntity((long) i, "정현우" + i, new HashSet<>());
+      Student student = new Student((long) i, "정현우" + i, new HashSet<>());
       students.add(student);
     }
     for (int i=1; i < 35; ++i){
-      LectureJpaEntity lecture = new LectureJpaEntity((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
       lectures.add(lecture);
     }
     for (int i = 0; i < 10; ++i){
-      StudentLectureJpaEntity studentLecture = new StudentLectureJpaEntity(students.get(i), lectures.get(i), i % 2 == 0);
+      StudentLecture studentLecture = new StudentLecture(students.get(i), lectures.get(i), i % 2 == 0);
       studentLectures.add(studentLecture);
     }
   }
@@ -54,14 +54,14 @@ public class EnrolledLectureUseCaseTest {
   @DisplayName("강의 신청 완료 여부 확인 테스트, 수강 성공")
   public void checkLectureEnrollment_success() {
     //Given
-    StudentJpaEntity student = students.get(5);
-    List<StudentLectureJpaEntity> filtered = studentLectures.stream()
+    Student student = students.get(5);
+    List<StudentLecture> filtered = studentLectures.stream()
             .filter(studentLecture -> studentLecture.getStudent().getId().equals(student.getId()))
             .collect(Collectors.toList());
 
     when(studentLectureRepository.findAllByStudentId(student.getId())).thenReturn(filtered);
 
-    EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(student.getId());
+    EnrolledLectureAPIResponse response = enrolledLectureUseCase.execute(student.getId());
     assertThat(response.enrolledLectures()).isNotEmpty();
     assertThat(response.status()).isTrue();
     verify(studentLectureRepository, times(1)).findAllByStudentId(student.getId());
@@ -71,10 +71,10 @@ public class EnrolledLectureUseCaseTest {
   @DisplayName("강의 신청 완료 여부 확인 테스트, 수강 실패")
   public void checkLectureEnrollment_fail() {
     //Given
-    StudentJpaEntity student = students.get(2);
+    Student student = students.get(2);
     when(studentLectureRepository.findAllByStudentId(student.getId())).thenReturn(List.of());
 
-    EnrolledLectureAPIResponse response = checkLectureEnrollmentUseCase.execute(student.getId());
+    EnrolledLectureAPIResponse response = enrolledLectureUseCase.execute(student.getId());
     assertThat(response.status()).isFalse();
     verify(studentLectureRepository, times(1)).findAllByStudentId(student.getId());
   }

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
@@ -1,0 +1,70 @@
+package io.hhplus.lecture_apply_service.domain.lecture.application.useCase;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCaseImpl;
+import io.hhplus.lecture_apply_service.application.port.out.LectureLock;
+import io.hhplus.lecture_apply_service.exception.CustomException;
+import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class ListLectureUseCaseTest {
+
+
+  private LectureRepository lectureRepository = Mockito.mock(LectureRepository.class);;
+
+  private ListLectureUseCase listLectureUseCase = new ListLectureUseCaseImpl(lectureRepository);
+
+  private List<LectureJpaEntity> lectures;
+
+  @BeforeEach
+  void setUp(){
+
+    lectures = new ArrayList<>();
+
+
+  }
+  @Test
+  @DisplayName("강의 목록 조회")
+  void listLectures_found(){
+    //given
+    for (int i=1; i < 35; ++i){
+      LectureJpaEntity lecture = new LectureJpaEntity((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+    }
+    when(lectureRepository.findAll()).thenReturn(lectures);
+
+    //when
+    ListLectureAPIResponse response = listLectureUseCase.execute();
+    assertThat(response.lectures().size()).isEqualTo(lectures.size());
+    verify(lectureRepository, times(1)).findAll();
+  }
+
+  @Test
+  @DisplayName("강의 목록 조회, 강의 목록 없음")
+  void listLectures_notFound(){
+    //given
+    when(lectureRepository.findAll()).thenReturn(List.of());
+
+    //when
+    assertThrows (CustomException.class, ()->listLectureUseCase.execute());
+
+    verify(lectureRepository, times(1)).findAll();
+  }
+}

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
@@ -12,6 +12,7 @@ import io.hhplus.lecture_apply_service.exception.CustomException;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -43,7 +44,8 @@ public class ListLectureUseCaseTest {
   void listLectures_found(){
     //given
     for (int i=1; i < 35; ++i){
-      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      LocalDateTime localDateTime = LocalDateTime.now();
+      Lecture lecture = new Lecture((long)i, localDateTime,"클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
       lectures.add(lecture);
     }
     when(lectureRepository.findAll()).thenReturn(lectures);

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/application/useCase/ListLectureUseCaseTest.java
@@ -9,8 +9,8 @@ import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCaseImpl;
 import io.hhplus.lecture_apply_service.application.port.out.LectureLock;
 import io.hhplus.lecture_apply_service.exception.CustomException;
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
-import io.hhplus.lecture_apply_service.infrastructure.entity.StudentJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+
 import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import java.time.LocalDateTime;
@@ -20,8 +20,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 public class ListLectureUseCaseTest {
@@ -31,7 +29,7 @@ public class ListLectureUseCaseTest {
 
   private ListLectureUseCase listLectureUseCase = new ListLectureUseCaseImpl(lectureRepository);
 
-  private List<LectureJpaEntity> lectures;
+  private List<Lecture> lectures;
 
   @BeforeEach
   void setUp(){
@@ -45,7 +43,7 @@ public class ListLectureUseCaseTest {
   void listLectures_found(){
     //given
     for (int i=1; i < 35; ++i){
-      LectureJpaEntity lecture = new LectureJpaEntity((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
       lectures.add(lecture);
     }
     when(lectureRepository.findAll()).thenReturn(lectures);

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/integrated/LectureTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/integrated/LectureTest.java
@@ -1,0 +1,335 @@
+package io.hhplus.lecture_apply_service.domain.lecture.integrated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
+import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
+import io.hhplus.lecture_apply_service.exception.CustomException;
+import io.hhplus.lecture_apply_service.exception.ErrorCode;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Student;
+import io.hhplus.lecture_apply_service.infrastructure.entity.StudentLecture;
+import io.hhplus.lecture_apply_service.infrastructure.repository.LectureRepository;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentLectureRepository;
+import io.hhplus.lecture_apply_service.infrastructure.repository.StudentRepository;
+import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LectureTest {
+
+  private List<Lecture> lectures = new ArrayList<>();
+  private List<Student> students = new ArrayList<>();
+
+
+
+  @Autowired
+  private StudentRepository studentRepository;
+
+  @Autowired
+  private LectureRepository lectureRepository;
+
+  @Autowired
+  private StudentLectureRepository studentLectureRepository;
+
+  @Autowired
+  private ApplyLectureUseCase applyLectureUseCase;
+  @Autowired
+  private EnrolledLectureUseCase enrolledLectureUseCase;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+
+  @Test
+  @DisplayName("특강 신청 테스트 - 성공")
+  public void applyLecture_success() throws Exception {
+
+    for (int i=1; i < 35; ++i){
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 1; i < 40; ++i) {
+      Student student = new Student((long) i, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+    //given
+    Student student = students.get(2);
+    Lecture lecture = lectures.get(3);
+    boolean applySuccess = true;
+    ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(student.getId(), lecture.getId());
+
+    //when
+    ResultActions resultActions = mockMvc.perform(post("/lectures/apply")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+
+        //then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.studentId").value(student.getId()))
+        .andExpect(jsonPath("$.lectureId").value(lecture.getId()))
+        .andExpect(jsonPath("$.status").value(applySuccess));
+  }
+
+  @Test
+  @DisplayName("특강 신청 테스트 - 실패")
+  public void applyLecture_Fail() throws Exception {
+
+    for (int i=1; i < 35; ++i){
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 1; i < 40; ++i) {
+      Student student = new Student((long) i, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+    //given
+    Student student = students.get(2);
+    Lecture lecture = lectures.get(0);
+    boolean applySuccess = false;
+    ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(student.getId(), lecture.getId());
+
+    //when
+    ResultActions resultActions = mockMvc.perform(post("/lectures/apply")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+
+        //then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.studentId").value(student.getId()))
+        .andExpect(jsonPath("$.lectureId").value(lecture.getId()))
+        .andExpect(jsonPath("$.status").value(applySuccess));
+  }
+
+  @Test
+  @DisplayName("수강하는 특강 목록 조회 테스트 - 성공")
+  public void listAllLecture_success() throws Exception {
+    for (int i=1; i < 35; ++i){
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 1; i < 40; ++i) {
+      Student student = new Student((long) i, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+    //given
+    Student student = students.get(2);
+    Lecture lecture = lectures.get(4);
+    StudentLecture studentLecture = new StudentLecture(student, lecture, true);
+    studentLectureRepository.save(studentLecture);
+
+
+    //when
+    EnrolledLectureAPIResponse response = enrolledLectureUseCase.execute(student.getId());
+
+    //then
+    assertThat(response.status()).isTrue();
+
+        //.andExpect(jsonPath("$.lectures.length()").value(greaterThan(0)));
+  }
+
+  @Test
+  @DisplayName("특강 목록 테스트 - 성공")
+  public void enrolledLecture_success() throws Exception {
+    //given
+    for (int i=1; i < 35; ++i){
+      Lecture lecture = new Lecture((long)i, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 1; i < 40; ++i) {
+      Student student = new Student((long) i, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+
+    //when
+    ResultActions resultActions = mockMvc.perform(get("/lectures"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lectures").isArray())
+        .andExpect(jsonPath("$.lectures.length()").value(lectures.size()));
+
+    // Optionally, perform more detailed assertions on individual lectures
+    for (int i = 0; i < lectures.size(); i++) {
+      Lecture expectedLecture = lectures.get(i);
+      resultActions.andExpect(jsonPath("$.lectures[" + i + "].id").value(expectedLecture.getId()))
+          .andExpect(jsonPath("$.lectures[" + i + "].name").value(expectedLecture.getName()))
+          .andExpect(jsonPath("$.lectures[" + i + "].capacity").value(expectedLecture.getCapacity()))
+          .andExpect(jsonPath("$.lectures[" + i + "].open_at").value(expectedLecture.getOpen_at().toString()+":00"));
+      // Add more assertions as needed
+    }
+  }
+
+  @Test
+  @DisplayName("특강 신청 동시성 테스트 - 성공")
+  public void applyLectureConcurrency_success() throws Exception {
+    //given
+    for (int i=0; i < 50; ++i){
+      Lecture lecture = new Lecture((long)i+1, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 0; i < 100; ++i) {
+      Student student = new Student((long) i+1, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+    Lecture lecture = lectures.get(38);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(students.size());
+    CountDownLatch latch = new CountDownLatch(students.size());
+    List<Future<ApplyLectureAPIResponse>> futures = new ArrayList<>();
+
+    //when
+    for (int i = 0; i < students.size(); ++i){
+      ApplyLectureCommand command = ApplyLectureCommand.builder()
+          .studentId(students.get(i).getId())
+          .lectureId(lecture.getId())
+          .build();
+      Future<ApplyLectureAPIResponse> future =
+          executorService.submit(()->
+              applyLectureUseCase.execute(command)
+          );
+      futures.add(future);
+    }
+
+    AtomicInteger yes = new AtomicInteger();
+    AtomicInteger no = new AtomicInteger();
+    futures.stream().forEach(future ->{
+      try {
+        ApplyLectureAPIResponse response = future.get();
+        if (response.status() == true){
+          yes.getAndIncrement();
+        }
+        else {
+          no.getAndIncrement();
+        }
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      catch ( CustomException e){
+        int a = 0;
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      } finally {
+        latch.countDown();
+      }
+    });
+    //then
+    latch.await();
+    executorService.shutdown();
+    assertThat(yes.get()).isEqualTo(lecture.getCapacity());
+  }
+
+  @Test
+  @DisplayName("특강 신청 동시성 테스트 신청자 중 이미 수강한 특강을 신청함 - 성공")
+  public void applyAlreadyDidLectureConcurrency_success() throws Exception {
+    //given
+    int studentNum = 100;
+    int lectureNum = 50;
+    int alreadyApplied = 12;
+    for (int i=0; i < lectureNum; ++i){
+      Lecture lecture = new Lecture((long)i+1, "클린 아키텍처"+i, i-1, LocalDateTime.of(2024,4,27,13,0) ,new HashSet<>());
+      lectures.add(lecture);
+      lectureRepository.save(lecture);
+    }
+    for (int i = 0; i < studentNum; ++i) {
+      Student student = new Student((long) i+1, "정현우" + i, new HashSet<>());
+      students.add(student);
+      studentRepository.save(student);
+    }
+    Lecture lecture = lectures.get(38);
+    for (int i = 0; i < alreadyApplied; ++i){
+      StudentLecture studentLecture = new StudentLecture(students.get(i), lecture, true);
+      studentLectureRepository.save(studentLecture);
+    }
+
+
+    ExecutorService executorService = Executors.newFixedThreadPool(students.size());
+    CountDownLatch latch = new CountDownLatch(students.size());
+    List<Future<ApplyLectureAPIResponse>> futures = new ArrayList<>();
+
+    //when
+    for (int i = 0; i < students.size(); ++i){
+      ApplyLectureCommand command = ApplyLectureCommand.builder()
+          .studentId(students.get(i).getId())
+          .lectureId(lecture.getId())
+          .build();
+      Future<ApplyLectureAPIResponse> future =
+          executorService.submit(()->
+              applyLectureUseCase.execute(command)
+          );
+      futures.add(future);
+    }
+
+    AtomicInteger yes = new AtomicInteger();
+    AtomicInteger no = new AtomicInteger();
+    AtomicInteger applied = new AtomicInteger();
+    futures.stream().forEach(future ->{
+            try {
+                ApplyLectureAPIResponse response = future.get();
+                if (response.status() == true){
+                    yes.getAndIncrement();
+                }
+                else {
+                    no.getAndIncrement();
+                }
+            } catch (InterruptedException | ExecutionException e) {
+              if (!(((CustomException) e.getCause()).getErrorCode() == ErrorCode.ALREADY_APPLIED)){
+                throw new RuntimeException(e);
+              }
+              else {
+                applied.getAndIncrement();
+              }
+            }
+            finally {
+                latch.countDown();
+            }
+        });
+    //then
+    latch.await();
+    executorService.shutdown();
+    assertThat(yes.get()).isEqualTo(lecture.getCapacity());
+    assertThat(applied.get()).isEqualTo(alreadyApplied);
+  }
+}

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/integrated/LectureTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/integrated/LectureTest.java
@@ -258,6 +258,9 @@ public class LectureTest {
     //then
     latch.await();
     executorService.shutdown();
+    List<StudentLecture> history = studentLectureRepository.findAll();
+    List<StudentLecture> success = history.stream().filter(his->his.getEnrollment() == true).toList();
+    assertThat(success.size()).isEqualTo(lecture.getCapacity());
     assertThat(yes.get()).isEqualTo(lecture.getCapacity());
   }
 
@@ -329,6 +332,9 @@ public class LectureTest {
     //then
     latch.await();
     executorService.shutdown();
+    List<StudentLecture> history = studentLectureRepository.findAll();
+    List<StudentLecture> success = history.stream().filter(his->his.getEnrollment() == true).toList();
+    assertThat(history.size()).isEqualTo(studentNum);
     assertThat(yes.get()).isEqualTo(lecture.getCapacity());
     assertThat(applied.get()).isEqualTo(alreadyApplied);
   }

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
@@ -5,6 +5,7 @@ import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
 import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
+import io.hhplus.lecture_apply_service.application.port.out.persistence.LectureId;
 import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.presentation.dto.LectureController;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
@@ -59,7 +60,7 @@ public class LectureControllerTest {
 
         for (int i = 0; i < 3; ++i){
             Lecture lecture = new Lecture();
-            lecture.setTmpId((long)i);
+            lecture.setId(new LectureId((long)i, LocalDateTime.of(2024,4,27,13,i+21)));
             lecture.setName("클린 아키텍처"+i);
             lecture.setCapacity(30);
             lecture.setOpen_at(LocalDateTime.of(2024,4,27,13,i+30));

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
@@ -59,7 +59,7 @@ public class LectureControllerTest {
 
         for (int i = 0; i < 3; ++i){
             Lecture lecture = new Lecture();
-            lecture.setId((long)i);
+            lecture.setTmpId((long)i);
             lecture.setName("클린 아키텍처"+i);
             lecture.setCapacity(30);
             lecture.setOpen_at(LocalDateTime.of(2024,4,27,13,i+30));
@@ -84,11 +84,12 @@ public class LectureControllerTest {
         Long userId = 1L;
         Long lectureId = 100L;
         boolean applySuccess = true;
-        ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, applySuccess);
+        LocalDateTime localDateTime = LocalDateTime.now();
+        ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, localDateTime, applySuccess);
         //when
         when(applyLectureUseCase.execute(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
 
-        ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId);
+        ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId, localDateTime, LocalDateTime.now());
         mockMvc.perform(post("/lectures/apply")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -107,11 +108,12 @@ public class LectureControllerTest {
         Long userId = 1L;
         Long lectureId = 100L;
         boolean applySuccess = false;
-        ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, applySuccess);
+        LocalDateTime localDateTime = LocalDateTime.now();
+        ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, localDateTime, applySuccess);
         when(applyLectureUseCase.execute(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
 
         //when
-        ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId);
+        ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId, localDateTime, LocalDateTime.now());
         mockMvc.perform(post("/lectures/apply")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
@@ -3,9 +3,15 @@ package io.hhplus.lecture_apply_service.domain.lecture.presentation.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
+import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
+import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
 import io.hhplus.lecture_apply_service.presentation.dto.LectureController;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +23,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,6 +41,36 @@ public class LectureControllerTest {
 
     @MockBean
     private ApplyLectureUseCase applyLectureUseCase;
+
+    @MockBean
+    private ListLectureUseCase listLectureUseCase;
+
+    @Test
+    @DisplayName("특강 목록 조회")
+    void listAllLecturesSuccess() throws Exception{
+        //given
+        List<LectureJpaEntity> lectures = new ArrayList<>();
+
+
+        for (int i = 0; i < 3; ++i){
+            LectureJpaEntity lecture = new LectureJpaEntity();
+            lecture.setId((long)i);
+            lecture.setName("클린 아키텍처"+i);
+            lecture.setCapacity(30);
+            lecture.setOpen_at(LocalDateTime.of(2024,4,27,13,i+30));
+            lectures.add(lecture);
+        }
+        ListLectureAPIResponse response = new ListLectureAPIResponse(lectures);
+        when(listLectureUseCase.execute()).thenReturn(response);
+
+        mockMvc.perform(get("/lectures"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.lectures[0].name").value(lectures.get(0).getName()))
+            .andExpect(jsonPath("$.lectures[1].name").value(lectures.get(1).getName()))
+            .andExpect(jsonPath("$.lectures[2].name").value(lectures.get(2).getName()));
+    }
+
 
     @Test
     @DisplayName("특강 신청 성공")

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
@@ -5,7 +5,7 @@ import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
 import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
-import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
+import io.hhplus.lecture_apply_service.infrastructure.entity.Lecture;
 import io.hhplus.lecture_apply_service.presentation.dto.LectureController;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
@@ -54,11 +54,11 @@ public class LectureControllerTest {
     @DisplayName("특강 목록 조회")
     void listAllLecturesSuccess() throws Exception{
         //given
-        List<LectureJpaEntity> lectures = new ArrayList<>();
+        List<Lecture> lectures = new ArrayList<>();
 
 
         for (int i = 0; i < 3; ++i){
-            LectureJpaEntity lecture = new LectureJpaEntity();
+            Lecture lecture = new Lecture();
             lecture.setId((long)i);
             lecture.setName("클린 아키텍처"+i);
             lecture.setCapacity(30);
@@ -86,7 +86,7 @@ public class LectureControllerTest {
         boolean applySuccess = true;
         ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, applySuccess);
         //when
-        when(applyLectureUseCase.applyLecture(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
+        when(applyLectureUseCase.execute(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
 
         ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId);
         mockMvc.perform(post("/lectures/apply")
@@ -97,7 +97,7 @@ public class LectureControllerTest {
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.studentId").value(userId))
                         .andExpect(jsonPath("$.lectureId").value(lectureId))
-                        .andExpect(jsonPath("$.success").value(applySuccess));
+                        .andExpect(jsonPath("$.status").value(applySuccess));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class LectureControllerTest {
         Long lectureId = 100L;
         boolean applySuccess = false;
         ApplyLectureAPIResponse APIresponse = new ApplyLectureAPIResponse(userId, lectureId, applySuccess);
-        when(applyLectureUseCase.applyLecture(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
+        when(applyLectureUseCase.execute(any(ApplyLectureCommand.class))).thenReturn(APIresponse);
 
         //when
         ApplyLectureAPIRequest request = new ApplyLectureAPIRequest(userId, lectureId);
@@ -119,8 +119,7 @@ public class LectureControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.studentId").value(userId))
                 .andExpect(jsonPath("$.lectureId").value(lectureId))
-                .andExpect(jsonPath("$.success").value(applySuccess))
-                .andExpect(jsonPath("$.success").value(applySuccess));
+                .andExpect(jsonPath("$.status").value(applySuccess));
     }
 
     @Test
@@ -136,7 +135,7 @@ public class LectureControllerTest {
         mockMvc.perform(get("/lectures/application/"+studentId)
                 .param("lectureId", "1"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true));
+            .andExpect(jsonPath("$.status").value(true));
     }
 
     @Test
@@ -152,6 +151,6 @@ public class LectureControllerTest {
         mockMvc.perform(get("/lectures/application/"+studentId)
                 .param("lectureId", "1"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(false));
+            .andExpect(jsonPath("$.status").value(false));
     }
 }

--- a/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
+++ b/src/test/java/io/hhplus/lecture_apply_service/domain/lecture/presentation/controller/LectureControllerTest.java
@@ -3,11 +3,13 @@ package io.hhplus.lecture_apply_service.domain.lecture.presentation.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ApplyLectureCommand;
+import io.hhplus.lecture_apply_service.application.port.in.EnrolledLectureUseCase;
 import io.hhplus.lecture_apply_service.application.port.in.ListLectureUseCase;
 import io.hhplus.lecture_apply_service.infrastructure.entity.LectureJpaEntity;
 import io.hhplus.lecture_apply_service.presentation.dto.LectureController;
 import io.hhplus.lecture_apply_service.presentation.dto.req.ApplyLectureAPIRequest;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ApplyLectureAPIResponse;
+import io.hhplus.lecture_apply_service.presentation.dto.res.EnrolledLectureAPIResponse;
 import io.hhplus.lecture_apply_service.presentation.dto.res.ListLectureAPIResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -44,6 +46,9 @@ public class LectureControllerTest {
 
     @MockBean
     private ListLectureUseCase listLectureUseCase;
+
+    @MockBean
+    private EnrolledLectureUseCase checkLectureEnrollmentUseCase;
 
     @Test
     @DisplayName("특강 목록 조회")
@@ -116,5 +121,37 @@ public class LectureControllerTest {
                 .andExpect(jsonPath("$.lectureId").value(lectureId))
                 .andExpect(jsonPath("$.success").value(applySuccess))
                 .andExpect(jsonPath("$.success").value(applySuccess));
+    }
+
+    @Test
+    @DisplayName("특강 신청 여부 조회, 수강 신청 성공")
+    void checkLectureEnrollment_true() throws Exception{
+        //given
+        long studentId = 2L;
+        long lectureId = 3L;
+
+        EnrolledLectureAPIResponse response = new EnrolledLectureAPIResponse(List.of(),true);
+        when(checkLectureEnrollmentUseCase.execute(studentId)).thenReturn(response);
+
+        mockMvc.perform(get("/lectures/application/"+studentId)
+                .param("lectureId", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("특강 신청 여부 조회, 수강 신청 실패")
+    void checkLectureEnrollment_false() throws Exception{
+        //given
+        long studentId = 2L;
+        long lectureId = 3L;
+
+        EnrolledLectureAPIResponse response = new EnrolledLectureAPIResponse(List.of(),false);
+        when(checkLectureEnrollmentUseCase.execute(studentId)).thenReturn(response);
+
+        mockMvc.perform(get("/lectures/application/"+studentId)
+                .param("lectureId", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(false));
     }
 }


### PR DESCRIPTION
## 수정내용
- 동시성
	- be41f50fe9be4483ba9fcbc56f1e78fa4a4c2704
	- Repository method에 비관적 락 사용
	- 일관된 잠금 순서를 유지하기 위해 `LectureRepository`의 메서드에만 PESSIMISTIC_WRITE 락을 적용하는 방식으로 변경
- ERD 수정
	- fede19bf62fd2f31896724998fad5b35330564b7
![20240628_044326](https://github.com/adiospain/hhplus-lecture-apply-service-java/assets/171418785/594f865b-6b7a-4bb1-ad07-532cd35bf051)


- Request 파라미터 추가
	- `startAt` 파라미터로 다른 날짜의 동일한 이름의 특강을 구분
	- `requestAt` 파라미터로 클라이언트에서부터 특강 신청 시간을 측정하여 특강 신청 기간에만 신청할 수 있도록 사용
		


## 리뷰 포인트
- 6e3798191b5ef11f4cc6c02129bd9995d694c8ea
	- 멘토링 때 말씀해주신 대로 Lecture 테이블에 start_at 이라는 PK 컬럼을 추가했습니다.
- 통합테스트 오류
		@SpringBootTest 어노테이션을 붙이고, 통합테스트 진행 시 오류가 발생했습니다.
		Lecture 엔티티에 tmpId와 id 필드가 중복으로 존재했는데, id 필드가 `StudentLecture` 엔티티와 제대로 매핑되지 않는 오류였습니다.
`StudentLecture` 엔티티에 'start_at' @JoinColumn을 추가하여 해결했습니다. (4afc5b820a74f8c04300baeefb2120f6726302d6)

> 오류메시지:
>	Caused by: org.hibernate.MappingException: A '@JoinColumn' references a column named 'id' but the target entity 'io.hhplus.lecture_apply_service.infrastructure.entity.Lecture' has no property which maps to this column



- 수정 전엔 `LectureTest`와 `ApplyUseCaseTest` 유닛테스트로 동시성 테스트를 진행했습니다. 수정 후 `ApplyUseCaseTest` 유닛테스트를 통해 동시성 테스트하며 코드 작성했습니다.
![20240628_041928](https://github.com/adiospain/hhplus-lecture-apply-service-java/assets/171418785/74b4013d-2ad5-4ddd-a032-a56f95a67d9b)
